### PR TITLE
Add react-ssd1306 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [react-hardware](https://github.com/iamdustan/react-hardware) - React Hardware enables you to build firmata-based hardware applications using React.
 * [react-dmx](https://github.com/alexanderson1993/react-dmx) - Use React components to control lights and devices with DMX channels
+* [react-ssd1306](https://github.com/doodlewind/react-ssd1306) - A React Renderer for SSD1306 OLED chip on Raspberry Pi.
 
 <a name="email" />
 
@@ -117,6 +118,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [tiny-react-renderer](https://github.com/iamdustan/tiny-react-renderer) - Learn you a React Renderer for Great Good.
 * [Making-a-custom-React-renderer](https://github.com/nitin42/Making-a-custom-React-renderer) - Tutorial on how to make a custom React renderer.
 * [⚛️👆Beginners guide to React Renderers. How to build your own renderer from scratch?](https://blog.atulr.com/react-custom-renderer-1/)
+* [Render React to Embedded LCD](https://github.com/doodlewind/react-ssd1306/blob/master/docs/tutorial.md) - Tutorial for building a React renderer that dynamically updates an OLED chip, based on the embeddable QuickJS intepreter, native C driver modules, and a HTML5 canvas emulator.
 
 ## License
 


### PR DESCRIPTION
This PR adds links to an educational React renderer.

This renderer displays text and pixels on a 0.96-inch OLED screen. It's built on top of a C driver for I2C protocol, which is used as a C module for the embeddable QuickJS engine. The whole codebase, including JS engine, C modules and React Reconciler, are compiled into binary within 780KB on a Raspberry Pi. A detailed writeup and a HTML5 canvas emulator are also included.

Checkout the resources here:

Code - https://github.com/doodlewind/react-ssd1306
Tutorial - https://github.com/doodlewind/react-ssd1306/blob/master/docs/tutorial.md

Hope it helps as a beginner’s guide, to those who are interested in developing custom React renderers :)